### PR TITLE
replace ::set-output in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
         id: tagName
         run: |
           TAG=${GITHUB_REF##*/}
-          echo ::set-output name=tag::${TAG}
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Update the 'Release' GitHub Action workflow to replace the deprecated ::set-output command with the newer $GITHUB_OUTPUT file mechanism.

Related issue:
 - https://github.com/pomerium/internal/issues/1511